### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -25,7 +25,7 @@ jobs:
         run: echo ::set-output name=TAGS::next
 
       - name: Docker
-        uses: elgohr/Publish-Docker-Github-Action@3.02
+        uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           CI_BRANCH: ${{ github.ref }}
           CI_COMMIT: ${{ github.sha }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore